### PR TITLE
Allow PaymentPlans weeks and duration be defined in seeds

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,7 +106,7 @@ module ApplicationHelper
        place_name: Place.find(params[:place_id]).name,
        single_class_price_by_kind: PaymentPlan.single_class_by_kind
          .transform_values { |p| number_to_currency(p.price) },
-       payment_plans: PaymentPlan.all.order(:order, :price).to_a.select { |p| !p.other? }.map { |p|
+       payment_plans: PaymentPlan.active.order(:order, :price).to_a.select { |p| !p.other? }.map { |p|
          { code: p.code, description: p.description, price: p.price.to_f }
        },
        teachers: Teacher.for_classes.to_a.map { |t| { id: t.id, name: t.name } },

--- a/app/models/payment_plan.rb
+++ b/app/models/payment_plan.rb
@@ -1,3 +1,28 @@
+#
+# Algunos planes de pago tienen significado especial. Estos deberían tener una
+# `description` dado por las constantes OTHER, SINGLE_CLASS, etc.
+#
+# Cuántas clases y por cuánto tiempo es válido un pack depende del valor de varias
+# propiedades.
+#
+# (1) Si `single_class == true`, es una clase individual y se usa en el mes en curso.
+#     Por lo general son clases que se usan en el dia
+#
+# Si `single_class == false` entonces se ven los campos `weekly_classes`, `weeks` y `due_date_months`.
+#
+# `due_date_months` indica cuántos meses dura el pack. Por lo general es `1`. Esto indica que
+# termina en el mes actual. El valor `2` es el mes siguiente. O sea, es la cantidad de meses que dura el pack.
+#
+# (2) Si `weeks == nil` entonces se calcula cuántas semanas hay desde el inicio de este mes hasta el
+#     el final del mes indicado por `due_date_months`. Esa cantidad de semanas se multiplica por `weekly_classes`
+#     para determinar la cantidad de clases que corresponden a la compra del pack. En este caso dependerá del mes
+#     en curso el valor exacto. `weeks == nil` suele darse en packs de 2 y 3 meses por simplificación.
+#
+# (3) Si `weeks != nil` entonces la cantidad de cursos corresponde exactamente a `weeks * weekly_classes`.
+#     Este caso suele darse en packs de 1 mes y hay packs para meses de 3, 4 y 5 semanas.
+#
+# Ver `StudentPack.register_for` que es donde se detalla esta lógica.
+#
 class PaymentPlan < ActiveRecord::Base
   OTHER = "OTRO"
   SINGLE_CLASS = "CLASE"

--- a/app/models/payment_plan.rb
+++ b/app/models/payment_plan.rb
@@ -33,7 +33,6 @@ class PaymentPlan < ActiveRecord::Base
   validates :price, numericality: true
 
   scope :active, -> { where("deleted_at IS NULL") }
-  scope :single_class_payment_plans, -> { where(code: [SINGLE_CLASS, SINGLE_CLASS_AFRO, SINGLE_CLASS_ROOTS, SINGLE_CLASS_FREE]) }
   scope :reference_single_class_payment_plans, -> { where(code: [SINGLE_CLASS, SINGLE_CLASS_AFRO, SINGLE_CLASS_ROOTS]) }
 
   def other?
@@ -42,10 +41,6 @@ class PaymentPlan < ActiveRecord::Base
 
   def single_class?
     self.code == SINGLE_CLASS || self.code == SINGLE_CLASS_ROOTS || self.code == SINGLE_CLASS_AFRO || self.code == SINGLE_CLASS_FREE
-  end
-
-  def self.single_class
-    find_by(code: SINGLE_CLASS)
   end
 
   def self.single_class_by_kind

--- a/app/models/payment_plan.rb
+++ b/app/models/payment_plan.rb
@@ -7,6 +7,7 @@ class PaymentPlan < ActiveRecord::Base
 
   validates :price, numericality: true
 
+  scope :active, -> { where("deleted_at IS NULL") }
   scope :single_class_payment_plans, -> { where(code: [SINGLE_CLASS, SINGLE_CLASS_AFRO, SINGLE_CLASS_ROOTS, SINGLE_CLASS_FREE]) }
   scope :reference_single_class_payment_plans, -> { where(code: [SINGLE_CLASS, SINGLE_CLASS_AFRO, SINGLE_CLASS_ROOTS]) }
 
@@ -43,7 +44,7 @@ class PaymentPlan < ActiveRecord::Base
   end
 
   def self.updatable_prices
-    PaymentPlan.all.order(:order, :price)
+    PaymentPlan.active.order(:order, :price)
       .to_a.select { |p| !p.other? && p.code != SINGLE_CLASS_FREE }
   end
 end

--- a/app/models/payment_plan.rb
+++ b/app/models/payment_plan.rb
@@ -16,10 +16,11 @@
 # (2) Si `weeks == nil` entonces se calcula cuántas semanas hay desde el inicio de este mes hasta el
 #     el final del mes indicado por `due_date_months`. Esa cantidad de semanas se multiplica por `weekly_classes`
 #     para determinar la cantidad de clases que corresponden a la compra del pack. En este caso dependerá del mes
-#     en curso el valor exacto. `weeks == nil` suele darse en packs de 2 y 3 meses por simplificación.
+#     en curso el valor exacto. `weeks == nil` suele darse en packs de 2 y 3 meses por simplificación, y en packs
+#     de 1 mes de duración pero para 2 o 3 veces por semana.
 #
 # (3) Si `weeks != nil` entonces la cantidad de cursos corresponde exactamente a `weeks * weekly_classes`.
-#     Este caso suele darse en packs de 1 mes y hay packs para meses de 3, 4 y 5 semanas.
+#     Este caso suele darse en packs de 1 vez por semana durante 1 mes y hay packs para meses de 3, 4 y 5 semanas.
 #
 # Ver `StudentPack.register_for` que es donde se detalla esta lógica.
 #

--- a/app/models/payment_plan.rb
+++ b/app/models/payment_plan.rb
@@ -40,7 +40,8 @@ class PaymentPlan < ActiveRecord::Base
   end
 
   def single_class?
-    self.code == SINGLE_CLASS || self.code == SINGLE_CLASS_ROOTS || self.code == SINGLE_CLASS_AFRO || self.code == SINGLE_CLASS_FREE
+    # TODO after migration remove hardcoded ids?
+    self.single_class || self.code == SINGLE_CLASS || self.code == SINGLE_CLASS_ROOTS || self.code == SINGLE_CLASS_AFRO || self.code == SINGLE_CLASS_FREE
   end
 
   def self.single_class_by_kind

--- a/app/models/student_pack.rb
+++ b/app/models/student_pack.rb
@@ -42,7 +42,11 @@ class StudentPack < ActiveRecord::Base
     plan = payment_plan_on_cashier || PaymentPlan.find_by(price: price)
     start_date = date.to_date.at_beginning_of_month
     if plan && !plan.single_class?
-      if plan.code == "3_MESES"
+      if !plan.due_date_months.nil?
+        # TODO after migration remove all cases and leave only the next one
+        # by default we use due_date_months == 1
+        due_date = (start_date + ((plan.due_date_months || 1) - 1).months).at_end_of_month
+      elsif plan.code == "3_MESES"
         due_date = (start_date + 2.months).at_end_of_month
       elsif plan.code == "2_MESES_LIBRE"
         due_date = (start_date + 1.months).at_end_of_month
@@ -52,29 +56,34 @@ class StudentPack < ActiveRecord::Base
         due_date = start_date.at_end_of_month
       end
 
-      case plan.code
-      when "1_X_SEMANA_3"
-        weeks = 3
-      when "1_X_SEMANA_3_CASH"
-        weeks = 3
-      when "1_X_SEMANA_4"
-        weeks = 4
-      when "1_X_SEMANA_4_CASH"
-        weeks = 4
-      when "1_X_SEMANA_4_SALE_30"
-        weeks = 4
-      when "1_X_SEMANA_4_SALE_50"
-        weeks = 4
-      when "1_X_SEMANA_5"
-        weeks = 5
-      when "1_X_SEMANA_5_CASH"
-        weeks = 5
+      if !plan.weeks.nil?
+        weeks = plan.weeks
       else
-        current_date = start_date
-        weeks = 0
-        while current_date <= due_date
-          current_date = current_date + 1.week
-          weeks += 1
+        # TODO after migration leave only the else case
+        case plan.code
+        when "1_X_SEMANA_3"
+          weeks = 3
+        when "1_X_SEMANA_3_CASH"
+          weeks = 3
+        when "1_X_SEMANA_4"
+          weeks = 4
+        when "1_X_SEMANA_4_CASH"
+          weeks = 4
+        when "1_X_SEMANA_4_SALE_30"
+          weeks = 4
+        when "1_X_SEMANA_4_SALE_50"
+          weeks = 4
+        when "1_X_SEMANA_5"
+          weeks = 5
+        when "1_X_SEMANA_5_CASH"
+          weeks = 5
+        else
+          current_date = start_date
+          weeks = 0
+          while current_date <= due_date
+            current_date = current_date + 1.week
+            weeks += 1
+          end
         end
       end
 

--- a/db/migrate/20220419151044_add_duration_fields_to_payment_plans.rb
+++ b/db/migrate/20220419151044_add_duration_fields_to_payment_plans.rb
@@ -1,0 +1,9 @@
+class AddDurationFieldsToPaymentPlans < ActiveRecord::Migration
+  def change
+    add_column :payment_plans, :single_class, :boolean
+    add_column :payment_plans, :weeks, :integer
+    add_column :payment_plans, :due_date_months, :integer
+
+    add_column :payment_plans, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200128005404) do
+ActiveRecord::Schema.define(version: 20220419151044) do
 
   create_table "activity_logs", force: :cascade do |t|
     t.string   "type",         limit: 255
@@ -89,14 +89,18 @@ ActiveRecord::Schema.define(version: 20200128005404) do
   end
 
   create_table "payment_plans", force: :cascade do |t|
-    t.string   "code",           limit: 255
-    t.string   "description",    limit: 255
-    t.decimal  "price",                      precision: 10, scale: 2
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
-    t.integer  "weekly_classes", limit: 4
-    t.integer  "order",          limit: 4
-    t.string   "course_match",   limit: 255
+    t.string   "code",            limit: 255
+    t.string   "description",     limit: 255
+    t.decimal  "price",                       precision: 10, scale: 2
+    t.datetime "created_at",                                           null: false
+    t.datetime "updated_at",                                           null: false
+    t.integer  "weekly_classes",  limit: 4
+    t.integer  "order",           limit: 4
+    t.string   "course_match",    limit: 255
+    t.boolean  "single_class",    limit: 1
+    t.integer  "weeks",           limit: 4
+    t.integer  "due_date_months", limit: 4
+    t.datetime "deleted_at"
   end
 
   create_table "places", force: :cascade do |t|
@@ -248,7 +252,6 @@ ActiveRecord::Schema.define(version: 20200128005404) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["teacher_id"], name: "index_users_on_teacher_id", using: :btree
 
-  add_foreign_key "cards", "students"
   add_foreign_key "courses", "places"
   add_foreign_key "courses", "tracks"
   add_foreign_key "student_course_logs", "course_logs"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -364,37 +364,37 @@ course "DANZA_AFRO_MAR", name: "Danza Afro - Martes", weekday: 2, valid_since: D
 course "AFRO_URBANO_MIE", name: "Afro Urbano - Miércoles", weekday: 3, valid_since: Date.new(2018,12,1), track: track("AFRO_URBANO"), place: swing_city, start_time: '18:00', valid_until: nil
 course "AFRO_URBANO_VIE", name: "Afro Urbano - Viernes", weekday: 5, valid_since: Date.new(2018,12,1), track: track("AFRO_URBANO"), place: swing_city, start_time: '18:00', valid_until: nil
 
-payment_plan "LIBRE", description: "Swing: 1 Mes. Libre", price: 2800, weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan "2_MESES_LIBRE", description: "Swing: 2 Meses. Libre", price: 4600, weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 2, order: 1, course_match: "swing"
-payment_plan "3_MESES", description: "Swing: 3 Meses 1 x Semana", price: 1950, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
-payment_plan "3_X_SEMANA", description: "Swing: Mensual 3 x Semana", price: 1900, weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
-payment_plan "2_X_SEMANA", description: "Swing: Mensual 2 x Semana", price: 1700, weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 2, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_3", description: "Swing: Mensual 1 x Semana (3 c)", price: 680, weekly_classes: 1, single_class: false, weeks: 3, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_4", description: "Swing: Mensual 1 x Semana (4 c)", price: 900, weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_5", description: "Swing: Mensual 1 x Semana (5 c)", price: 1120, weekly_classes: 1, single_class: false, weeks: 5, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan PaymentPlan::SINGLE_CLASS, description: "Swing: Clase suelta", price: 270, weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 1, course_match: "swing"
+payment_plan "LIBRE", description: "Swing: 1 Mes. Libre", weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "2_MESES_LIBRE", description: "Swing: 2 Meses. Libre", weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 2, order: 1, course_match: "swing"
+payment_plan "3_MESES", description: "Swing: 3 Meses 1 x Semana", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
+payment_plan "3_X_SEMANA", description: "Swing: Mensual 3 x Semana", weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
+payment_plan "2_X_SEMANA", description: "Swing: Mensual 2 x Semana", weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 2, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_3", description: "Swing: Mensual 1 x Semana (3 c)", weekly_classes: 1, single_class: false, weeks: 3, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_4", description: "Swing: Mensual 1 x Semana (4 c)", weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_5", description: "Swing: Mensual 1 x Semana (5 c)", weekly_classes: 1, single_class: false, weeks: 5, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan PaymentPlan::SINGLE_CLASS, description: "Swing: Clase suelta", weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 1, course_match: "swing"
 payment_plan PaymentPlan::OTHER, description: "Swing: Otro (monto a continuación)", price: 0, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: nil, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_4_SALE_30", description: "Swing: Mensual 1 x Semana (4 c) -30%", price: 630, weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 2, course_match: "swing", deleted_at: Date.new(2022,4,1)
-payment_plan "1_X_SEMANA_4_SALE_50", description: "Swing: Mensual 1 x Semana (4 c) -50%", price: 450, weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 2, course_match: "swing", deleted_at: Date.new(2022,4,1)
+payment_plan "1_X_SEMANA_4_SALE_30", description: "Swing: Mensual 1 x Semana (4 c) -30%", weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 2, course_match: "swing", deleted_at: Date.new(2022,4,1)
+payment_plan "1_X_SEMANA_4_SALE_50", description: "Swing: Mensual 1 x Semana (4 c) -50%", weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 2, course_match: "swing", deleted_at: Date.new(2022,4,1)
 payment_plan PaymentPlan::SINGLE_CLASS_FREE, description: "Swing: Clase bonificada", price: 0, weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 2, course_match: "swing"
 
-payment_plan PaymentPlan::SINGLE_CLASS_ROOTS, description: "Roots: Clase suelta", price: 270, weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
-payment_plan "ROOTS__1_X_SEMANA", description: "Roots: Mensual 1 x Semana", price: 900, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
-payment_plan "ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana", price: 1700, weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 2, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
-payment_plan "ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana", price: 2200, weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 3, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
+payment_plan PaymentPlan::SINGLE_CLASS_ROOTS, description: "Roots: Clase suelta", weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
+payment_plan "ROOTS__1_X_SEMANA", description: "Roots: Mensual 1 x Semana", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
+payment_plan "ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana", weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 2, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
+payment_plan "ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana", weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 3, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
 
-payment_plan PaymentPlan::SINGLE_CLASS_AFRO, description: "Roots: Clase suelta de Danza Afro", price: 300, weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 4, course_match: "afro", deleted_at: Date.new(2022,4,1)
-payment_plan "AFRO__1_X_SEMANA", description: "Roots: Mensual 1 x Semana de Danza Afro", price: 1100, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 4, course_match: "afro", deleted_at: Date.new(2022,4,1)
-payment_plan "AFRO-1ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana con Danza Afro", price: 1800, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 2, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
-payment_plan "AFRO-2ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana con Danza Afro", price: 2600, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
+payment_plan PaymentPlan::SINGLE_CLASS_AFRO, description: "Roots: Clase suelta de Danza Afro", weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 4, course_match: "afro", deleted_at: Date.new(2022,4,1)
+payment_plan "AFRO__1_X_SEMANA", description: "Roots: Mensual 1 x Semana de Danza Afro", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 4, course_match: "afro", deleted_at: Date.new(2022,4,1)
+payment_plan "AFRO-1ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana con Danza Afro", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 2, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
+payment_plan "AFRO-2ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana con Danza Afro", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
 
-payment_plan "1_X_SEMANA_3_CASH", description: "Swing: Mensual 1 x Semana (3 c) - EFECTIVO", price: 2000, weekly_classes: 1, single_class: false, weeks: 3, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_4_CASH", description: "Swing: Mensual 1 x Semana (4 c) - EFECTIVO", price: 2600, weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_5_CASH", description: "Swing: Mensual 1 x Semana (5 c) - EFECTIVO", price: 3200, weekly_classes: 1, single_class: false, weeks: 5, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan "3_X_SEMANA_CASH", description: "Swing: Mensual 3 x Semana - EFECTIVO", price: 4400, weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan "2_X_SEMANA_CASH", description: "Swing: Mensual 2 x Semana - EFECTIVO", price: 6200, weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan "LIBRE_CASH", description: "Swing: 1 Mes. Libre - EFECTIVO", price: 10000, weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
-payment_plan "3_MESES_CASH", description: "Swing: 3 Meses 1 x Semana - EFECTIVO", price: 0, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_3_CASH", description: "Swing: Mensual 1 x Semana (3 c) - EFECTIVO", weekly_classes: 1, single_class: false, weeks: 3, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_4_CASH", description: "Swing: Mensual 1 x Semana (4 c) - EFECTIVO", weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_5_CASH", description: "Swing: Mensual 1 x Semana (5 c) - EFECTIVO", weekly_classes: 1, single_class: false, weeks: 5, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "3_X_SEMANA_CASH", description: "Swing: Mensual 3 x Semana - EFECTIVO", weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "2_X_SEMANA_CASH", description: "Swing: Mensual 2 x Semana - EFECTIVO", weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "LIBRE_CASH", description: "Swing: 1 Mes. Libre - EFECTIVO", weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "3_MESES_CASH", description: "Swing: 3 Meses 1 x Semana - EFECTIVO", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
 
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -367,8 +367,8 @@ course "AFRO_URBANO_VIE", name: "Afro Urbano - Viernes", weekday: 5, valid_since
 payment_plan "LIBRE", description: "Swing: 1 Mes. Libre", weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
 payment_plan "2_MESES_LIBRE", description: "Swing: 2 Meses. Libre", weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 2, order: 1, course_match: "swing"
 payment_plan "3_MESES", description: "Swing: 3 Meses 1 x Semana", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
-payment_plan "3_X_SEMANA", description: "Swing: Mensual 3 x Semana", weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
-payment_plan "2_X_SEMANA", description: "Swing: Mensual 2 x Semana", weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 2, order: 1, course_match: "swing"
+payment_plan "3_X_SEMANA", description: "Swing: Mensual 3 x Semana", weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "2_X_SEMANA", description: "Swing: Mensual 2 x Semana", weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
 payment_plan "1_X_SEMANA_3", description: "Swing: Mensual 1 x Semana (3 c)", weekly_classes: 1, single_class: false, weeks: 3, due_date_months: 1, order: 1, course_match: "swing"
 payment_plan "1_X_SEMANA_4", description: "Swing: Mensual 1 x Semana (4 c)", weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 1, course_match: "swing"
 payment_plan "1_X_SEMANA_5", description: "Swing: Mensual 1 x Semana (5 c)", weekly_classes: 1, single_class: false, weeks: 5, due_date_months: 1, order: 1, course_match: "swing"
@@ -380,13 +380,13 @@ payment_plan PaymentPlan::SINGLE_CLASS_FREE, description: "Swing: Clase bonifica
 
 payment_plan PaymentPlan::SINGLE_CLASS_ROOTS, description: "Roots: Clase suelta", weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
 payment_plan "ROOTS__1_X_SEMANA", description: "Roots: Mensual 1 x Semana", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
-payment_plan "ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana", weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 2, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
-payment_plan "ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana", weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 3, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
+payment_plan "ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana", weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 1, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
+payment_plan "ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana", weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 1, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
 
 payment_plan PaymentPlan::SINGLE_CLASS_AFRO, description: "Roots: Clase suelta de Danza Afro", weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 4, course_match: "afro", deleted_at: Date.new(2022,4,1)
 payment_plan "AFRO__1_X_SEMANA", description: "Roots: Mensual 1 x Semana de Danza Afro", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 4, course_match: "afro", deleted_at: Date.new(2022,4,1)
-payment_plan "AFRO-1ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana con Danza Afro", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 2, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
-payment_plan "AFRO-2ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana con Danza Afro", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
+payment_plan "AFRO-1ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana con Danza Afro", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
+payment_plan "AFRO-2ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana con Danza Afro", weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
 
 payment_plan "1_X_SEMANA_3_CASH", description: "Swing: Mensual 1 x Semana (3 c) - EFECTIVO", weekly_classes: 1, single_class: false, weeks: 3, due_date_months: 1, order: 1, course_match: "swing"
 payment_plan "1_X_SEMANA_4_CASH", description: "Swing: Mensual 1 x Semana (4 c) - EFECTIVO", weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 1, course_match: "swing"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -364,37 +364,37 @@ course "DANZA_AFRO_MAR", name: "Danza Afro - Martes", weekday: 2, valid_since: D
 course "AFRO_URBANO_MIE", name: "Afro Urbano - Miércoles", weekday: 3, valid_since: Date.new(2018,12,1), track: track("AFRO_URBANO"), place: swing_city, start_time: '18:00', valid_until: nil
 course "AFRO_URBANO_VIE", name: "Afro Urbano - Viernes", weekday: 5, valid_since: Date.new(2018,12,1), track: track("AFRO_URBANO"), place: swing_city, start_time: '18:00', valid_until: nil
 
-payment_plan "LIBRE", description: "Swing: 1 Mes. Libre", price: 2800, weekly_classes: 40, order: 1, course_match: "swing"
-payment_plan "2_MESES_LIBRE", description: "Swing: 2 Meses. Libre", price: 4600, weekly_classes: 40, order: 1, course_match: "swing"
-payment_plan "3_MESES", description: "Swing: 3 Meses 1 x Semana", price: 1950, weekly_classes: 1, order: 1, course_match: "swing"
-payment_plan "3_X_SEMANA", description: "Swing: Mensual 3 x Semana", price: 1900, weekly_classes: 3, order: 1, course_match: "swing"
-payment_plan "2_X_SEMANA", description: "Swing: Mensual 2 x Semana", price: 1700, weekly_classes: 2, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_3", description: "Swing: Mensual 1 x Semana (3 c)", price: 680, weekly_classes: 1, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_4", description: "Swing: Mensual 1 x Semana (4 c)", price: 900, weekly_classes: 1, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_5", description: "Swing: Mensual 1 x Semana (5 c)", price: 1120, weekly_classes: 1, order: 1, course_match: "swing"
-payment_plan PaymentPlan::SINGLE_CLASS, description: "Swing: Clase suelta", price: 270, weekly_classes: 1, order: 1, course_match: "swing"
-payment_plan PaymentPlan::OTHER, description: "Swing: Otro (monto a continuación)", price: 0, weekly_classes: 1, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_4_SALE_30", description: "Swing: Mensual 1 x Semana (4 c) -30%", price: 630, weekly_classes: 1, order: 2, course_match: "swing"
-payment_plan "1_X_SEMANA_4_SALE_50", description: "Swing: Mensual 1 x Semana (4 c) -50%", price: 450, weekly_classes: 1, order: 2, course_match: "swing"
-payment_plan PaymentPlan::SINGLE_CLASS_FREE, description: "Swing: Clase bonificada", price: 0, weekly_classes: 1, order: 2, course_match: "swing"
+payment_plan "LIBRE", description: "Swing: 1 Mes. Libre", price: 2800, weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "2_MESES_LIBRE", description: "Swing: 2 Meses. Libre", price: 4600, weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 2, order: 1, course_match: "swing"
+payment_plan "3_MESES", description: "Swing: 3 Meses 1 x Semana", price: 1950, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
+payment_plan "3_X_SEMANA", description: "Swing: Mensual 3 x Semana", price: 1900, weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
+payment_plan "2_X_SEMANA", description: "Swing: Mensual 2 x Semana", price: 1700, weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 2, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_3", description: "Swing: Mensual 1 x Semana (3 c)", price: 680, weekly_classes: 1, single_class: false, weeks: 3, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_4", description: "Swing: Mensual 1 x Semana (4 c)", price: 900, weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_5", description: "Swing: Mensual 1 x Semana (5 c)", price: 1120, weekly_classes: 1, single_class: false, weeks: 5, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan PaymentPlan::SINGLE_CLASS, description: "Swing: Clase suelta", price: 270, weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 1, course_match: "swing"
+payment_plan PaymentPlan::OTHER, description: "Swing: Otro (monto a continuación)", price: 0, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: nil, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_4_SALE_30", description: "Swing: Mensual 1 x Semana (4 c) -30%", price: 630, weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 2, course_match: "swing", deleted_at: Date.new(2022,4,1)
+payment_plan "1_X_SEMANA_4_SALE_50", description: "Swing: Mensual 1 x Semana (4 c) -50%", price: 450, weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 2, course_match: "swing", deleted_at: Date.new(2022,4,1)
+payment_plan PaymentPlan::SINGLE_CLASS_FREE, description: "Swing: Clase bonificada", price: 0, weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 2, course_match: "swing"
 
-payment_plan PaymentPlan::SINGLE_CLASS_ROOTS, description: "Roots: Clase suelta", price: 270, weekly_classes: 1, order: 3, course_match: "roots"
-payment_plan "ROOTS__1_X_SEMANA", description: "Roots: Mensual 1 x Semana", price: 900, weekly_classes: 1, order: 3, course_match: "roots"
-payment_plan "ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana", price: 1700, weekly_classes: 2, order: 3, course_match: "roots"
-payment_plan "ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana", price: 2200, weekly_classes: 3, order: 3, course_match: "roots"
+payment_plan PaymentPlan::SINGLE_CLASS_ROOTS, description: "Roots: Clase suelta", price: 270, weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
+payment_plan "ROOTS__1_X_SEMANA", description: "Roots: Mensual 1 x Semana", price: 900, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
+payment_plan "ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana", price: 1700, weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 2, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
+payment_plan "ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana", price: 2200, weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 3, order: 3, course_match: "roots", deleted_at: Date.new(2022,4,1)
 
-payment_plan PaymentPlan::SINGLE_CLASS_AFRO, description: "Roots: Clase suelta de Danza Afro", price: 300, weekly_classes: 1, order: 4, course_match: "afro"
-payment_plan "AFRO__1_X_SEMANA", description: "Roots: Mensual 1 x Semana de Danza Afro", price: 1100, weekly_classes: 1, order: 4, course_match: "afro"
-payment_plan "AFRO-1ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana con Danza Afro", price: 1800, weekly_classes: 1, order: 4, course_match: "afro,roots"
-payment_plan "AFRO-2ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana con Danza Afro", price: 2600, weekly_classes: 1, order: 4, course_match: "afro,roots"
+payment_plan PaymentPlan::SINGLE_CLASS_AFRO, description: "Roots: Clase suelta de Danza Afro", price: 300, weekly_classes: 1, single_class: true, weeks: nil, due_date_months: nil, order: 4, course_match: "afro", deleted_at: Date.new(2022,4,1)
+payment_plan "AFRO__1_X_SEMANA", description: "Roots: Mensual 1 x Semana de Danza Afro", price: 1100, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 1, order: 4, course_match: "afro", deleted_at: Date.new(2022,4,1)
+payment_plan "AFRO-1ROOTS__2_X_SEMANA", description: "Roots: Mensual 2 x Semana con Danza Afro", price: 1800, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 2, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
+payment_plan "AFRO-2ROOTS__3_X_SEMANA", description: "Roots: Mensual 3 x Semana con Danza Afro", price: 2600, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 4, course_match: "afro,roots", deleted_at: Date.new(2022,4,1)
 
-payment_plan "1_X_SEMANA_3_CASH", description: "Swing: Mensual 1 x Semana (3 c) - EFECTIVO", price: 2000, weekly_classes: 1, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_4_CASH", description: "Swing: Mensual 1 x Semana (4 c) - EFECTIVO", price: 2600, weekly_classes: 1, order: 1, course_match: "swing"
-payment_plan "1_X_SEMANA_5_CASH", description: "Swing: Mensual 1 x Semana (5 c) - EFECTIVO", price: 3200, weekly_classes: 1, order: 1, course_match: "swing"
-payment_plan "3_X_SEMANA_CASH", description: "Swing: Mensual 3 x Semana - EFECTIVO", price: 4400, weekly_classes: 3, order: 1, course_match: "swing"
-payment_plan "2_X_SEMANA_CASH", description: "Swing: Mensual 2 x Semana - EFECTIVO", price: 6200, weekly_classes: 2, order: 1, course_match: "swing"
-payment_plan "LIBRE_CASH", description: "Swing: 1 Mes. Libre - EFECTIVO", price: 10000, weekly_classes: 40, order: 1, course_match: "swing"
-payment_plan "3_MESES_CASH", description: "Swing: 3 Meses 1 x Semana - EFECTIVO", price: 0, weekly_classes: 1, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_3_CASH", description: "Swing: Mensual 1 x Semana (3 c) - EFECTIVO", price: 2000, weekly_classes: 1, single_class: false, weeks: 3, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_4_CASH", description: "Swing: Mensual 1 x Semana (4 c) - EFECTIVO", price: 2600, weekly_classes: 1, single_class: false, weeks: 4, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "1_X_SEMANA_5_CASH", description: "Swing: Mensual 1 x Semana (5 c) - EFECTIVO", price: 3200, weekly_classes: 1, single_class: false, weeks: 5, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "3_X_SEMANA_CASH", description: "Swing: Mensual 3 x Semana - EFECTIVO", price: 4400, weekly_classes: 3, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "2_X_SEMANA_CASH", description: "Swing: Mensual 2 x Semana - EFECTIVO", price: 6200, weekly_classes: 2, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "LIBRE_CASH", description: "Swing: 1 Mes. Libre - EFECTIVO", price: 10000, weekly_classes: 40, single_class: false, weeks: nil, due_date_months: 1, order: 1, course_match: "swing"
+payment_plan "3_MESES_CASH", description: "Swing: 3 Meses 1 x Semana - EFECTIVO", price: 0, weekly_classes: 1, single_class: false, weeks: nil, due_date_months: 3, order: 1, course_match: "swing"
 
 
 


### PR DESCRIPTION
Fixes #67 y elimina permite reemplazar los hacks en el código por datos. Se agrega documentación de la lógica.

Una vez que esto este integrado podemos eliminar las condiciones en el código 🎉 

Saqué el `price` de los seeds porque sino se van a pisar en producción cuando se corra.