### PR TITLE
Payment plan cleanup

### DIFF
--- a/app/models/payment_plan.rb
+++ b/app/models/payment_plan.rb
@@ -32,6 +32,7 @@ class PaymentPlan < ActiveRecord::Base
   SINGLE_CLASS_AFRO = "AFRO__CLASE"
 
   validates :price, numericality: true
+  validates :due_date_months, presence: true, if: :requires_due_date_months?
 
   scope :active, -> { where("deleted_at IS NULL") }
   scope :reference_single_class_payment_plans, -> { where(code: [SINGLE_CLASS, SINGLE_CLASS_AFRO, SINGLE_CLASS_ROOTS]) }
@@ -41,8 +42,7 @@ class PaymentPlan < ActiveRecord::Base
   end
 
   def single_class?
-    # TODO after migration remove hardcoded ids?
-    self.single_class || self.code == SINGLE_CLASS || self.code == SINGLE_CLASS_ROOTS || self.code == SINGLE_CLASS_AFRO || self.code == SINGLE_CLASS_FREE
+    self.single_class
   end
 
   def self.single_class_by_kind
@@ -55,6 +55,10 @@ class PaymentPlan < ActiveRecord::Base
 
   def requires_student_pack_for_class
     !self.single_class?
+  end
+
+  def requires_due_date_months?
+    !self.other? && !self.single_class?
   end
 
   def notify_purchase?

--- a/db/migrate/20220428005425_update_duration_fields_on_payment_plans.rb
+++ b/db/migrate/20220428005425_update_duration_fields_on_payment_plans.rb
@@ -1,0 +1,5 @@
+class UpdateDurationFieldsOnPaymentPlans < ActiveRecord::Migration
+  def change
+    change_column :payment_plans, :single_class, :boolean, :null => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220419151044) do
+ActiveRecord::Schema.define(version: 20220428005425) do
 
   create_table "activity_logs", force: :cascade do |t|
     t.string   "type",         limit: 255
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 20220419151044) do
     t.integer  "weekly_classes",  limit: 4
     t.integer  "order",           limit: 4
     t.string   "course_match",    limit: 255
-    t.boolean  "single_class",    limit: 1
+    t.boolean  "single_class",    limit: 1,                            null: false
     t.integer  "weeks",           limit: 4
     t.integer  "due_date_months", limit: 4
     t.datetime "deleted_at"

--- a/spec/factories/payment_plans.rb
+++ b/spec/factories/payment_plans.rb
@@ -5,6 +5,30 @@ FactoryGirl.define do
     price "50.00"
     weekly_classes 1
     course_match "swing"
+    single_class false
+
+    trait :single_class do
+      code PaymentPlan::SINGLE_CLASS
+      single_class true
+      price "70.00"
+      weekly_classes 1
+    end
+
+    trait :weekly_1_month do
+      code "weekly_1_month"
+      single_class false
+      price "200.00"
+      weekly_classes 1
+      due_date_months 1
+    end
+
+    trait :biweekly_1_month do
+      code "biweekly_1_month"
+      single_class false
+      price "400.00"
+      weekly_classes 2
+      due_date_months 1
+    end
   end
 
 end

--- a/spec/models/course_log_spec.rb
+++ b/spec/models/course_log_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CourseLog, type: :model do
-  let!(:plan_clase) { create(:payment_plan, code: PaymentPlan::SINGLE_CLASS, price: 70, weekly_classes: 1) }
+  let!(:plan_clase) { create(:payment_plan, :single_class) }
 
   it "factory works" do
     create(:course_log)
@@ -158,7 +158,7 @@ RSpec.describe CourseLog, type: :model do
     let(:caballito_course) { create(:course, weekday: 4, place: caballito) }
     let(:other_course) { create(:course, weekday: 4) }
     let(:teacher) { create(:teacher) }
-    let(:plan) { create(:payment_plan, weekly_classes: 1) }
+    let(:plan) { create(:payment_plan, weekly_classes: 1, due_date_months: 1) }
 
     context "yanking all student_course_logs" do
 

--- a/spec/models/ona_submission_spec.rb
+++ b/spec/models/ona_submission_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe OnaSubmission, type: :model do
   let!(:plan_otro) { create(:payment_plan, code: PaymentPlan::OTHER) }
-  let!(:plan_clase) { create(:payment_plan, code: PaymentPlan::SINGLE_CLASS, price: 70, weekly_classes: 1) }
-  let!(:plan_3_meses) { create(:payment_plan, code: "3_MESES", price: 550, weekly_classes: 1) }
-  let!(:plan_1_x_semana_4) { create(:payment_plan, code: "1_X_SEMANA_4", price: 250, weekly_classes: 1) }
+  let!(:plan_clase) { create(:payment_plan, :single_class) }
+  let!(:plan_3_meses) { create(:payment_plan, code: "3_MESES", price: 550, weekly_classes: 1, due_date_months: 3) }
+  let!(:plan_1_x_semana_4) { create(:payment_plan, code: "1_X_SEMANA_4", price: 250, weekly_classes: 1, due_date_months: 1, weeks: 4) }
 
   let(:lh_int1_jue) { create(:course, weekday: 4) }
   let(:ch_int2_jue) { create(:course, weekday: 4) }
@@ -222,7 +222,7 @@ RSpec.describe OnaSubmission, type: :model do
   end
 
   it "should register pending payment of amount given by the plan" do
-    plan = create(:payment_plan, price: 172)
+    plan = create(:payment_plan, price: 172, due_date_months: 1)
 
     submit_student({
       "student_repeat/id_kind" => "guest",
@@ -342,7 +342,7 @@ RSpec.describe OnaSubmission, type: :model do
   end
 
   it "should create guess without name if there is payment" do
-    plan = create(:payment_plan)
+    plan = create(:payment_plan, :weekly_1_month)
 
     submit_student({
       "student_repeat/id_kind" => "guest",
@@ -364,7 +364,7 @@ RSpec.describe OnaSubmission, type: :model do
   describe "transactional processing" do
 
     it "when teacher is missing and a payment is been submitted" do
-      plan = create(:payment_plan)
+      plan = create(:payment_plan, :weekly_1_month)
       student = create(:student)
 
       submission = issued_class({
@@ -388,7 +388,7 @@ RSpec.describe OnaSubmission, type: :model do
     end
 
     it "when a record not found do to a plan" do
-      plan = create(:payment_plan)
+      plan = create(:payment_plan, :weekly_1_month)
 
       submission = issued_class({
         "date" => "2015-05-14",
@@ -515,7 +515,7 @@ RSpec.describe OnaSubmission, type: :model do
   end
 
   it "reg bug with payment" do
-    plan = create(:payment_plan)
+    plan = create(:payment_plan, :weekly_1_month)
 
     issued_class ({
       "student_repeat" => [

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Place, type: :model do
   let(:place) { create(:place) }
   let(:caballito_course) { create(:course, weekday: 4, place: caballito) }
   let(:teacher) { create(:teacher) }
-  let(:plan_1w) { create(:payment_plan, weekly_classes: 1) }
-  let(:plan_2w) { create(:payment_plan, weekly_classes: 2) }
-  let!(:plan_clase) { create(:payment_plan, code: PaymentPlan::SINGLE_CLASS, price: 70, weekly_classes: 1) }
+  let(:plan_1w) { create(:payment_plan, :weekly_1_month) }
+  let(:plan_2w) { create(:payment_plan, :biweekly_1_month) }
+  let!(:plan_clase) { create(:payment_plan, :single_class) }
 
   it "should have commission if caballito" do
     expect(caballito.commission).to eq(0.3)

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe School, type: :model do
-  let!(:plan_clase) { create(:payment_plan, code: PaymentPlan::SINGLE_CLASS, price: 70, weekly_classes: 1) }
+  let!(:plan_clase) { create(:payment_plan, :single_class) }
 
   describe "courses incomes" do
     let(:teacher) { create(:teacher, fee: 100) }
-    let(:plan) { create(:payment_plan) }
+    let(:plan) { create(:payment_plan, :weekly_1_month) }
 
     it "count in the day they where transferred" do
       Timecop.freeze(Time.local(2015, 5, 15))

--- a/spec/models/student_course_log_spec.rb
+++ b/spec/models/student_course_log_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe StudentCourseLog, type: :model do
-  let!(:plan_clase) { create(:payment_plan, code: PaymentPlan::SINGLE_CLASS, price: 70, weekly_classes: 1) }
+  let!(:plan_clase) { create(:payment_plan, :single_class) }
 
   describe "factory" do
     it "should create" do
@@ -26,7 +26,7 @@ RSpec.describe StudentCourseLog, type: :model do
     end
 
     it "must have a teacher when paying" do
-      student_log = build(:student_course_log, teacher: nil, payment_plan: create(:payment_plan))
+      student_log = build(:student_course_log, teacher: nil, payment_plan: create(:payment_plan, :weekly_1_month))
       student_log.validate
       expect(student_log).to have_error_on(:teacher)
     end
@@ -59,14 +59,14 @@ RSpec.describe StudentCourseLog, type: :model do
     end
 
     it "should not be created twice" do
-      student_log = create(:student_course_log, payment_plan: create(:payment_plan))
+      student_log = create(:student_course_log, payment_plan: create(:payment_plan, :weekly_1_month))
       first_count = student_log.student.activity_logs.count
       student_log.save!
       expect(student_log.student.activity_logs.count).to eq(first_count)
     end
 
     it "should remove payment log" do
-      student_log = create(:student_course_log, payment_plan: create(:payment_plan))
+      student_log = create(:student_course_log, payment_plan: create(:payment_plan, :weekly_1_month))
       first_count = student_log.student.activity_logs.count
       student_log.payment_plan = nil
       student_log.save!
@@ -74,11 +74,11 @@ RSpec.describe StudentCourseLog, type: :model do
     end
 
     it "should update payment log message when payment is changed" do
-      student_log = create(:student_course_log, payment_plan: create(:payment_plan, price: '20.00'))
+      student_log = create(:student_course_log, payment_plan: create(:payment_plan, :weekly_1_month, price: '20.00'))
       first_count = student_log.student.activity_logs.count
 
       expect(payment(student_log).description).to start_with("Abonó 20")
-      student_log.payment_plan = create(:payment_plan, price: '30.00')
+      student_log.payment_plan = create(:payment_plan, :biweekly_1_month, price: '30.00')
       student_log.save!
       expect(student_log.student.activity_logs.count).to eq(first_count)
       expect(payment(student_log).description).to start_with("Abonó 30")

--- a/spec/models/student_pack_spec.rb
+++ b/spec/models/student_pack_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe StudentPack, type: :model do
     end
   end
 
-  let!(:plan_3_meses) { create(:payment_plan, code: "3_MESES", price: 550, weekly_classes: 1) }
-  let!(:plan_3_x_semana) { create(:payment_plan, code: "3_X_SEMANA", price: 500, weekly_classes: 3) }
-  let!(:plan_2_x_semana) { create(:payment_plan, code: "2_X_SEMANA", price: 400, weekly_classes: 2) }
-  let!(:plan_1_x_semana_3) { create(:payment_plan, code: "1_X_SEMANA_3", price: 180, weekly_classes: 1) }
-  let!(:plan_1_x_semana_4) { create(:payment_plan, code: "1_X_SEMANA_4", price: 250, weekly_classes: 1) }
-  let!(:plan_1_x_semana_5) { create(:payment_plan, code: "1_X_SEMANA_5", price: 300, weekly_classes: 1) }
-  let!(:plan_clase) { create(:payment_plan, code: PaymentPlan::SINGLE_CLASS, price: 70, weekly_classes: 1) }
+  let!(:plan_3_meses) { create(:payment_plan, code: "3_MESES", price: 550, weekly_classes: 1, due_date_months: 3) }
+  let!(:plan_3_x_semana) { create(:payment_plan, code: "3_X_SEMANA", price: 500, weekly_classes: 3, due_date_months: 1) }
+  let!(:plan_2_x_semana) { create(:payment_plan, code: "2_X_SEMANA", price: 400, weekly_classes: 2, due_date_months: 1) }
+  let!(:plan_1_x_semana_3) { create(:payment_plan, code: "1_X_SEMANA_3", price: 180, weekly_classes: 1, due_date_months: 1, weeks: 3) }
+  let!(:plan_1_x_semana_4) { create(:payment_plan, code: "1_X_SEMANA_4", price: 250, weekly_classes: 1, due_date_months: 1, weeks: 4) }
+  let!(:plan_1_x_semana_5) { create(:payment_plan, code: "1_X_SEMANA_5", price: 300, weekly_classes: 1, due_date_months: 1, weeks: 5) }
+  let!(:plan_clase) { create(:payment_plan, :single_class) }
   let!(:plan_otro) { create(:payment_plan, code: PaymentPlan::OTHER) }
 
   let(:student) { create(:student) }

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Teacher, type: :model do
-  let!(:plan_clase) { create(:payment_plan, code: PaymentPlan::SINGLE_CLASS, price: 70, weekly_classes: 1) }
+  let!(:plan_clase) { create(:payment_plan, :single_class) }
 
   describe "receive course money" do
     let(:teacher) { create(:teacher) }
-    let(:plan) { create(:payment_plan) }
+    let(:plan) { create(:payment_plan, :weekly_1_month) }
 
     before do
       Timecop.freeze Time.now.at_beginning_of_minute

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -17,7 +17,7 @@ RSpec.shared_context "swc context" do
   let!(:jane_doe) { create :student, first_name: "Jane", last_name: "Doe" }
 
   let(:single_class_price) { 100 }
-  let!(:single_class) { create :payment_plan, code: PaymentPlan::SINGLE_CLASS, description: "Clase suelta $#{single_class_price}", price: single_class_price, weekly_classes: 1 }
+  let!(:single_class) { create :payment_plan, :single_class, description: "Clase suelta $#{single_class_price}", price: single_class_price }
 
   def signin_as_room
     goto_page RoomLogin do |page|


### PR DESCRIPTION
Una vez que #68 esté aplicado y deployado se puede aplicar este cambio que:

1. Agregar un par de validaciones al modelo, sin haber migrado los datos como hace #68 no se pueden introducir dichas validaciones
2. Elimina los hacks sobre `PaymentPlan#code`
3. Actualiza los tests con respecto a estos cambios